### PR TITLE
Simplify GenericNode (allows stable support for GGCAT)

### DIFF
--- a/src/generic/mod.rs
+++ b/src/generic/mod.rs
@@ -77,9 +77,6 @@ impl<Graph: GraphBase> Eq for MappedNode<Graph> {}
 
 /// A node representing a unitig with the edges of a bidirected de Bruijn graph, inspired by bcalm2's fasta format.
 pub trait GenericNode {
-    /// The iterator used to iterate over this node's edges.
-    type EdgeIterator: Iterator<Item = GenericEdge>;
-
     /// A unique identifier of this node.
     /// The identifiers of the nodes need to be numbered consecutively starting from 0.
     fn id(&self) -> usize;
@@ -89,7 +86,7 @@ pub trait GenericNode {
 
     /// Return an iterator over the edges of the node.
     /// It is enough to return the edges that also bcalm2 would return.
-    fn edges(&self) -> Self::EdgeIterator;
+    fn edges(&self) -> impl Iterator<Item = GenericEdge>;
 }
 
 /// An edge representing a k-1 overlap between unitigs.


### PR DESCRIPTION
Hi,
with the stabilization of return_position_impl_trait_in_trait in Rust 1.75 the generic node can be simplified by removing the iterator type on the trait and put an impl return type on the edges() function.

This allows complex iterators (ex. done with closures) to be used in stable Rust, and it is the last step to transition from nightly to stable for GGCAT.